### PR TITLE
Attempt to resolve null safety issues

### DIFF
--- a/lib/src/form_builder_file_picker.dart
+++ b/lib/src/form_builder_file_picker.dart
@@ -158,7 +158,7 @@ class _FormBuilderFilePickerState
         resultList = await FilePicker.platform.pickFiles(
           type: widget.type,
           allowedExtensions: widget.allowedExtensions,
-          allowCompression: widget.allowCompression,
+          allowCompression: widget.allowCompression ?? true,
           onFileLoading: widget.onFileLoading,
           allowMultiple: widget.allowMultiple,
           withData: widget.withData,
@@ -239,7 +239,7 @@ class _FormBuilderFilePickerState
                       width: double.infinity,
                       color: Colors.white.withOpacity(.8),
                       child: Text(
-                        files[index].name!,
+                        files[index].name,
                         style: theme.textTheme.caption,
                         maxLines: 2,
                         overflow: TextOverflow.clip,

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -63,7 +63,7 @@ packages:
       name: file_picker
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "3.0.0"
+    version: "3.0.2+2"
   flutter:
     dependency: "direct main"
     description: flutter

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -11,7 +11,7 @@ dependencies:
     sdk: flutter
 
   flutter_form_builder: ^6.0.0
-  file_picker: ^3.0.0
+  file_picker: ^3.0.2
   permission_handler: ^6.1.1
   community_material_icon: ^5.9.55
 


### PR DESCRIPTION
Hey, I encountered null safety related issues and the compilation of my app fails. The error message read:

```
Launching lib/main.dart on Chrome in debug mode...
../../.pub-cache/hosted/pub.dartlang.org/form_builder_file_picker-1.2.0-nullsafety.0/lib/src/form_builder_file_picke
r.dart:161:36: Error: The argument type 'bool?' can't be assigned to the parameter type 'bool' because 'bool?' is
nullable and 'bool' isn't.
          allowCompression: widget.allowCompression,                    
                                   ^                                    
../../.pub-cache/hosted/pub.dartlang.org/form_builder_file_picker-1.2.0-nullsafety.0/lib/src/form_builder_file_picke
r.dart:242:38: Warning: Operand of null-aware operation '!' has type 'String' which excludes null.
                        files[index].name!,                             
                                     ^                                  
Waiting for connection from debug service on Chrome...             28.1s
Failed to compile application.
```

This PR provides a fix to the errors I encountered. Please also see: https://github.com/danvick/form_builder_file_picker/issues/12#issuecomment-855335765