### PR TITLE
Fixed: #17 when a file is picked, onChange is called twice.

### DIFF
--- a/lib/src/form_builder_file_picker.dart
+++ b/lib/src/form_builder_file_picker.dart
@@ -179,7 +179,6 @@ class _FormBuilderFilePickerState
       setState(() => _files!.addAll(resultList!.files));
       // TODO: Pick only remaining number
       field.didChange(_files);
-      widget.onChanged?.call(_files);
     }
   }
 
@@ -188,7 +187,6 @@ class _FormBuilderFilePickerState
       _files!.removeAt(index);
     });
     field.didChange(_files);
-    widget.onChanged?.call(_files);
   }
 
   Widget defaultFileViewer(


### PR DESCRIPTION
Both `field.didChange(_files);` and `widget.onChanged?.call(_files);` are triggering the `onChange` method

https://github.com/danvick/form_builder_file_picker/issues/17